### PR TITLE
[FEATURE] Bump Minor Version when a New Token is Added

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,3 +30,9 @@ jobs:
       with:
         name: tallycash.tokenlist.json
         path: build/tallycash.tokenlist.json
+    - name:  Automated Version Bump
+      uses:  'phips28/gh-action-bump-version@master'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+      with:
+        minor-wording:  'add-token'

--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ Tally is a community run DAO and welcomes contributions from anyone. If you woul
         "decimals": 18
       }]
 ```
-5. Commit and a pull request to merge the changes into the tallycash/tokenlist repo
-
+5. Commit with 'add-token' prepended to the commit message and a pull request to merge the changes into the tallycash/tokenlist repo
+> All commits must be [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) using the `-S` flag to be merged into the main repo. 
 ```
 git add .
 git commit -m 'add new token'

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Tally is a community run DAO and welcomes contributions from anyone. If you woul
 > All commits must be [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) using the `-S` flag to be merged into the main repo. 
 ```
 git add .
-git commit -m 'add new token'
+git commit -S -m 'add-token - 0xBitcoin'
 git push --set-upstream origin add-[token you are adding]-token
 ```
 ## Adding a token image


### PR DESCRIPTION
- Addresses issue #22 
- Increment version when add-token is prepended to a commit message
- Utilizes package [gh-action-bump-version](https://github.com/phips28/gh-action-bump-version)

### Dependencies

- This is dependent on the creation of a GH_TOKEN secret in the token-list repo with a https://github.com/tallycash github auth token.